### PR TITLE
Credly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM debian:stable-slim
+FROM debian:bookworm-slim
 
 LABEL org.opencontainers.image.authors="james@ejangi.com"
 
-ARG HUGO_VERSION=0.128.1
+ARG HUGO_VERSION=0.150.0
 
 RUN apt-get update && \
     apt-get install -y jpegoptim optipng
@@ -11,7 +11,7 @@ ADD https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_ext
 
 RUN tar -xf /tmp/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz -C /tmp && \
     mv /tmp/hugo /usr/local/bin/hugo && \
-    rm -rf /tmp/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz && \ 
+    rm -rf /tmp/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz && \
     rm -rf /tmp/LICENSE.md && \
     rm -rf /tmp/README.md
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.authors="james@ejangi.com"
 ARG HUGO_VERSION=0.150.0
 
 RUN apt-get update && \
-    apt-get install -y jpegoptim optipng
+    apt-get install -y jpegoptim optipng ca-certificates
 
 ADD https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz /tmp
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Gosh, the documentation on this is hopeless... So, here it is in a nutshell.
 2) Wherever you want the uri for the compiled CSS, add the following:
 
 ```html
-{{ $sass := resources.Get "scss/main.scss"  | resources.ToCSS (dict "outputStyle" "compressed") | fingerprint }}
+{{ $sass := resources.Get "scss/main.scss"  | css.Sass (dict "outputStyle" "compressed") | fingerprint }}
 <link rel="stylesheet" href="{{ $sass.Permalink }}">
 ```
 

--- a/config.toml
+++ b/config.toml
@@ -43,3 +43,4 @@ Github = "https://github.com/ejangi"
 Trailblazer = "https://trailblazer.me/id/ejangi"
 pieColors = ["#4A3FC9", "#C09F66", "#3A3D46", "#777777", "#FFFFFF"]
 CopyrightNotice = "&copy; James Angus 2020. View source on [Github](https://github.com/ejangi/ejangi.com)."
+CredlyId = "ejangi"

--- a/themes/ejangi/assets/scss/_home.scss
+++ b/themes/ejangi/assets/scss/_home.scss
@@ -162,6 +162,7 @@
 #projects,
 #about,
 #gold,
+#credly,
 #contact {
     @include padded;
     padding-top: ($gutter-md * 2);
@@ -303,6 +304,44 @@
 
         .icon {
             height: 64px;
+        }
+    }
+}
+
+#credly {
+    @include gradient-bg;
+
+    h2 {
+        color: $color-primary;
+    }
+
+    h3 {
+        color: $color-light;
+    }
+
+    .content {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        column-gap: 30px;
+        row-gap: 30px;
+        grid-auto-rows: 1fr;
+        margin-top: 2rem;
+
+        @media (min-width: $width-sm) {
+            margin-top: 3rem;
+        }
+
+        @media (min-width: $width-md) {
+            grid-template-columns: 1fr 1fr 1fr 1fr;
+        }
+
+        .badge {
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        iframe {
+            background-color: $color-light;
         }
     }
 }

--- a/themes/ejangi/layouts/index.html
+++ b/themes/ejangi/layouts/index.html
@@ -15,7 +15,7 @@
 
             <div class="location"><p><img src="{{ print "svg/location.svg" | absURL }}" width="9" height="12"> <small>{{ .Site.Params.Location }}</small></p></div>
         </div>
-        
+
         <div class="core-philosophy">
                 {{ if .Site.Params.CorePhilosophy -}}
                 <div class="quote">
@@ -35,7 +35,7 @@
             .webp #intro .core-philosophy {
                 background-image: url('{{ print "images/core-philosophy-bg-1x.webp" | absURL }}');
             }
-            @media (-webkit-min-device-pixel-ratio: 2) { 
+            @media (-webkit-min-device-pixel-ratio: 2) {
                 .webp #intro .core-philosophy {
                     background-image: url('{{ print "images/core-philosophy-bg.webp" | absURL }}');
                 }
@@ -45,7 +45,7 @@
             .no-webp #intro .core-philosophy {
                 background-image: url('{{ print "images/core-philosophy-bg-sm.jpg" | absURL }}');
             }
-            @media (-webkit-min-device-pixel-ratio: 2) { 
+            @media (-webkit-min-device-pixel-ratio: 2) {
                 .no-webp #intro .core-philosophy {
                     background-image: url('{{ print "images/core-philosophy-bg.jpg" | absURL }}');
                 }
@@ -91,7 +91,7 @@
     .webp #about {
         background-image: url('{{ print "images/about-bg-1x.webp" | absURL }}');
     }
-    @media (-webkit-min-device-pixel-ratio: 2) { 
+    @media (-webkit-min-device-pixel-ratio: 2) {
         .webp #about {
             background-image: url('{{ print "images/about-bg.webp" | absURL }}');
         }
@@ -101,11 +101,11 @@
     .no-webp #about {
         background-image: url('{{ print "images/about-bg-sm.jpg" | absURL }}');
     }
-    @media (-webkit-min-device-pixel-ratio: 2) { 
+    @media (-webkit-min-device-pixel-ratio: 2) {
         .no-webp #about {
             background-image: url('{{ print "images/about-bg.jpg" | absURL }}');
         }
-    } 
+    }
     {{ end }}
 </style>
 {{ end }}
@@ -128,6 +128,16 @@
             </article>
             {{ end }}
             {{ end }}
+        </div>
+    </div>
+</section>
+
+<section id="credly">
+    <div class="container">
+        <h2>Recent Credentials</h2>
+        <h3>Things I learned recently</h3>
+        <div class="content">
+            {{ partial "credly.html" .}}
         </div>
     </div>
 </section>

--- a/themes/ejangi/layouts/partials/credly.html
+++ b/themes/ejangi/layouts/partials/credly.html
@@ -1,15 +1,16 @@
 {{ $credlyUrl := printf "https://www.credly.com/users/%s/badges.json" .Site.Params.CredlyId }}
-<h3> Getting: {{ $credlyUrl }}</h3>
 {{ $data := dict }}
 {{ $credlyUrl := printf "https://www.credly.com/users/%s/badges.json" .Site.Params.CredlyId }}
 {{ with try (resources.GetRemote $credlyUrl) }}
   {{ with .Err }}
     {{ errorf "%s" . }}
   {{ else with .Value }}
-    {{ $credlyData = . | transform.Unmarshal }}
+    {{ $credlyData := . | transform.Unmarshal }}
     {{ $badges := $credlyData.data }}
     {{ range $badges }}
-        <div data-iframe-width="150" data-iframe-height="270" data-share-badge-id="{{ .id }}" data-share-badge-host="https://www.credly.com"></div>
+        <div class="badge">
+            <div data-iframe-width="200" data-iframe-height="240" data-share-badge-id="{{ .id }}" data-share-badge-host="https://www.credly.com"></div>
+        </div>
     {{ end }}
   {{ else }}
     {{ errorf "Unable to get remote resource %q" $credlyUrl }}

--- a/themes/ejangi/layouts/partials/credly.html
+++ b/themes/ejangi/layouts/partials/credly.html
@@ -1,0 +1,17 @@
+{{ $credlyUrl := printf "https://www.credly.com/users/%s/badges.json" .Site.Params.CredlyId }}
+<h3> Getting: {{ $credlyUrl }}</h3>
+{{ $data := dict }}
+{{ $credlyUrl := printf "https://www.credly.com/users/%s/badges.json" .Site.Params.CredlyId }}
+{{ with try (resources.GetRemote $credlyUrl) }}
+  {{ with .Err }}
+    {{ errorf "%s" . }}
+  {{ else with .Value }}
+    {{ $credlyData = . | transform.Unmarshal }}
+    {{ $badges := $credlyData.data }}
+    {{ range $badges }}
+        <div data-iframe-width="150" data-iframe-height="270" data-share-badge-id="{{ .id }}" data-share-badge-host="https://www.credly.com"></div>
+    {{ end }}
+  {{ else }}
+    {{ errorf "Unable to get remote resource %q" $credlyUrl }}
+  {{ end }}
+{{ end }}

--- a/themes/ejangi/layouts/partials/head.html
+++ b/themes/ejangi/layouts/partials/head.html
@@ -11,6 +11,9 @@
     <!-- Check browser for Webp support: -->
     <script src="{{ print "js/modernizr-custom.js" | absURL }}"></script>
     <script src="{{ print "js/ejangi.js" | absURL }}"></script>
+    {{ if .Site.Params.CredlyId }}
+    <script src="//cdn.credly.com/assets/utilities/embed.js" defer async></script>
+    {{ end }}
 
     {{ if (fileExists "static/images/favicon.svg") -}}
     <link rel="icon" type="image/svg+xml" href="{{ print "images/favicon.svg" | absURL }}" fetchpriority="low">
@@ -22,7 +25,7 @@
     {{ template "_internal/opengraph.html" . }}
     {{ template "_internal/twitter_cards.html" . }}
 
-    {{ $sass := resources.Get "scss/main.scss"  | resources.ToCSS (dict "outputStyle" "compressed") | fingerprint }}
+    {{ $sass := resources.Get "scss/main.scss"  | css.Sass (dict "outputStyle" "compressed") | fingerprint }}
     <link rel="stylesheet" href="{{ $sass.Permalink }}">
 
     {{ if .Site.Config.Services.GoogleAnalytics.ID }}


### PR DESCRIPTION
This release includes:

- An upgrade to Hugo 0.150.0
- An upgraded version of Debian for the docker container
- Data integration with Credly so that when a CredlyId is specified we pull the list of badges from the API and display the embedded badge iframes for each badge.
- Styling so the new block suits the frontpage of the website.